### PR TITLE
A tiny improvement in NPM scripts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint src",
-    "start": "node_modules/babel-cli/bin/babel-node.js src",
-    "credentials": "node_modules/babel-cli/bin/babel-node.js src -m credentials"
+    "start": "babel-node src",
+    "credentials": "babel-node src -m credentials"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
Same as: https://github.com/eshaham/israeli-bank-scrapers/pull/63

> Did you know the inside NPM scripts you can access your dependencies executables as if the where globals?
> 
> That means that:
> ```
> "prepublishOnly": "node_modules/babel-cli/bin/babel.js src --out-dir lib"
> ```
> 
> Is the same as:
> ```
> "prepublishOnly": "babel src --out-dir lib"
> ```
> 
> Nice, isn't it? 😊
> 