### PR TITLE
Add lib/ and .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# NPM package related
+lib/

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # NPM package related
 lib/
+
+# OS related
+.DS_Store


### PR DESCRIPTION
I've noticed that  `lib/` is ignored in `israeli-bank-scrapers` but not here.
Also added `.DS_Store`, annoying MacOS stuff (: