### PR TITLE
generalize the setup process to support multiple dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ The credentials for each scraper are encrypted and saved in an dedicated file on
 To save credentials for a specific scraper, run the following command and choose the scraper:
 
 ```bash
-npm run credentials
+npm run setup
 ```
+
+When asked 'What would you like to setup?' choose 'Scrapers'.
 
 ### Scraping
 Once you save the credentials for relevant scrapers, run the following command to start scraping:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint src",
     "start": "babel-node src",
     "start:debug": "npm start -- -s true",
-    "credentials": "npm start -- -m credentials"
+    "setup": "npm start -- -m setup"
   },
   "pre-commit": [
     "lint"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import yargs from 'yargs';
 import scrape from './scrape';
-import saveCredentials from './save-credentials';
+import setupMainMenu from './setup/setup-main-menu';
 
 const args = yargs.options({
   mode: {
@@ -17,6 +17,6 @@ const args = yargs.options({
 
 if (!args.mode || args.mode === 'scrape') {
   scrape(args.show);
-} else if (args.mode === 'credentials') {
-  saveCredentials();
+} else if (args.mode === 'setup') {
+  setupMainMenu();
 }

--- a/src/setup/setup-main-menu.js
+++ b/src/setup/setup-main-menu.js
@@ -1,0 +1,20 @@
+import inquirer from 'inquirer';
+
+import setupScrapers from './setup-scrapers';
+
+
+export default async function () {
+  const { next } = await inquirer.prompt({
+    type: 'list',
+    name: 'next',
+    message: 'What would you like to setup?',
+    choices: [
+      {
+        name: 'Scrapers',
+        value: setupScrapers,
+      },
+    ],
+  });
+
+  await next();
+}

--- a/src/setup/setup-scrapers.js
+++ b/src/setup/setup-scrapers.js
@@ -1,10 +1,10 @@
 import inquirer from 'inquirer';
 
-import PASSWORD_FIELD from './constants';
-import { CONFIG_FOLDER } from './definitions';
-import { SCRAPERS } from './helpers/scrapers';
-import { writeJsonFile } from './helpers/files';
-import { encryptCredentials } from './helpers/credentials';
+import PASSWORD_FIELD from '../constants';
+import { CONFIG_FOLDER } from '../definitions';
+import { SCRAPERS } from '../helpers/scrapers';
+import { writeJsonFile } from '../helpers/files';
+import { encryptCredentials } from '../helpers/credentials';
 
 function validateNonEmpty(field, input) {
   if (input) {


### PR DESCRIPTION
# Setup dialog
add new entry point to the library named 'setup' which is general and allow extending the setup process to support different setup scenarios such as #26 and #28.

@eshaham I think you should consider merging this one so both @asfktz and my self will be able to extend the setup process in our other PRs.
