### PR TITLE
generalize the scraping process to support tasks and currency conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ The credentials for each scraper are encrypted and saved in an dedicated file on
 To save credentials for a specific scraper, run the following command and choose the scraper:
 
 ```bash
-npm run credentials
+npm run setup
 ```
+
+When asked 'What would you like to setup?' choose 'Scrapers'.
 
 ### Scraping
 Once you save the credentials for relevant scrapers, run the following command to start scraping:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint src",
     "start": "babel-node src",
     "start:debug": "npm start -- -s true",
-    "credentials": "npm start -- -m credentials"
+    "setup": "npm start -- -m setup"
   },
   "pre-commit": [
     "lint"

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -1,0 +1,19 @@
+import { SETTINGS_FILE, DOWNLOAD_FOLDER } from '../definitions';
+import { writeJsonFile, readJsonFile } from './files';
+
+export async function readSettingsFile() {
+  let settings = await readJsonFile(SETTINGS_FILE);
+  if (!settings) {
+    settings = {
+      saveLocation: DOWNLOAD_FOLDER,
+    };
+  }
+
+  return settings;
+}
+
+export async function writeSettingsFile(settings) {
+  if (settings) {
+    await writeJsonFile(SETTINGS_FILE, settings);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import yargs from 'yargs';
 import scrape from './scrape';
-import saveCredentials from './save-credentials';
+import setupMainMenu from './setup/setup-main-menu';
 
 const args = yargs.options({
   mode: {
@@ -17,6 +17,6 @@ const args = yargs.options({
 
 if (!args.mode || args.mode === 'scrape') {
   scrape(args.show);
-} else if (args.mode === 'credentials') {
-  saveCredentials();
+} else if (args.mode === 'setup') {
+  setupMainMenu();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import scrape from './scrape';
+import scrape from './scrape/scrape-individual';
 import setupMainMenu from './setup/setup-main-menu';
 
 const args = yargs.options({

--- a/src/scrape/scrape-individual.js
+++ b/src/scrape/scrape-individual.js
@@ -2,10 +2,11 @@ import moment from 'moment';
 import inquirer from 'inquirer';
 import json2csv from 'json2csv';
 
-import { CONFIG_FOLDER, SETTINGS_FILE, DOWNLOAD_FOLDER } from './definitions';
-import { writeFile, readJsonFile, writeJsonFile } from './helpers/files';
-import { decryptCredentials } from './helpers/credentials';
-import { SCRAPERS, createScraper } from './helpers/scrapers';
+import { CONFIG_FOLDER } from '../definitions';
+import { writeFile, readJsonFile } from '../helpers/files';
+import { decryptCredentials } from '../helpers/credentials';
+import { SCRAPERS, createScraper } from '../helpers/scrapers';
+import { readSettingsFile, writeSettingsFile } from '../helpers/settings';
 
 async function getParameters(defaultSaveLocation) {
   const startOfMonthMoment = moment().startOf('month');
@@ -67,25 +68,17 @@ async function exportAccountData(scraperId, account, combineInstallments, saveLo
 }
 
 export default async function (showBrowser) {
-  let defaultSaveLocation = DOWNLOAD_FOLDER;
-  let settings = await readJsonFile(SETTINGS_FILE);
-  if (settings) {
-    defaultSaveLocation = settings.saveLocation;
-  } else {
-    settings = {
-      saveLocation: defaultSaveLocation,
-    };
-  }
+  const settings = await readSettingsFile();
   const {
     scraperId,
     combineInstallments,
     startDate,
     saveLocation,
-  } = await getParameters(defaultSaveLocation);
+  } = await getParameters(settings.saveLocation);
 
-  if (saveLocation !== defaultSaveLocation) {
+  if (saveLocation !== settings.saveLocation) {
     settings.saveLocation = saveLocation;
-    await writeJsonFile(SETTINGS_FILE, settings);
+    await writeSettingsFile(settings);
   }
 
   const encryptedCredentials = await readJsonFile(`${CONFIG_FOLDER}/${scraperId}.json`);

--- a/src/setup/setup-main-menu.js
+++ b/src/setup/setup-main-menu.js
@@ -1,0 +1,20 @@
+import inquirer from 'inquirer';
+
+import setupScrapers from './setup-scrapers';
+
+
+export default async function () {
+  const { next } = await inquirer.prompt({
+    type: 'list',
+    name: 'next',
+    message: 'What would you like to setup?',
+    choices: [
+      {
+        name: 'Scrapers',
+        value: setupScrapers,
+      },
+    ],
+  });
+
+  await next();
+}

--- a/src/setup/setup-main-menu.js
+++ b/src/setup/setup-main-menu.js
@@ -10,7 +10,7 @@ export default async function () {
     message: 'What would you like to setup?',
     choices: [
       {
-        name: 'Scrapers',
+        name: 'Individual Scrapers',
         value: setupScrapers,
       },
     ],

--- a/src/setup/setup-main-menu.js
+++ b/src/setup/setup-main-menu.js
@@ -2,19 +2,24 @@ import inquirer from 'inquirer';
 
 import setupScrapers from './setup-scrapers';
 
-
 export default async function () {
-  const { next } = await inquirer.prompt({
+  const { setupType } = await inquirer.prompt({
     type: 'list',
-    name: 'next',
+    name: 'setupType',
     message: 'What would you like to setup?',
     choices: [
       {
-        name: 'Individual Scrapers',
-        value: setupScrapers,
+        name: 'Setup a new scraper',
+        value: 'scraper',
       },
     ],
   });
 
-  await next();
+  switch (setupType) {
+    case 'scraper':
+      setupScrapers();
+      break;
+    default:
+      break;
+  }
 }

--- a/src/setup/setup-scrapers.js
+++ b/src/setup/setup-scrapers.js
@@ -1,10 +1,10 @@
 import inquirer from 'inquirer';
 
-import PASSWORD_FIELD from './constants';
-import { CONFIG_FOLDER } from './definitions';
-import { SCRAPERS } from './helpers/scrapers';
-import { writeJsonFile } from './helpers/files';
-import { encryptCredentials } from './helpers/credentials';
+import PASSWORD_FIELD from '../constants';
+import { CONFIG_FOLDER } from '../definitions';
+import { SCRAPERS } from '../helpers/scrapers';
+import { writeJsonFile } from '../helpers/files';
+import { encryptCredentials } from '../helpers/credentials';
 
 function validateNonEmpty(field, input) {
   if (input) {


### PR DESCRIPTION
# Setup process
### Extended setup process
add new entry point to the library named 'setup' which is needed to support different setup scenarios such as #26 and #28.

# Scraping process
### Rebranded scraping process
The existing `scraping` process was rebranded into `individual scraping` so we will be able to allow scraping either `individual scrapers` or `tasks` (#28) 

# Helpers Added
### Settings
a new helper `settings.js` was added and can be used to read and write into `settings.json` file.

---

@eshaham I think you should consider merging this one so both @asfktz and my self will be able to extend the setup process in our other PRs.
