### PR TITLE
filter transactions by status and by date

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,7 @@
 const PASSWORD_FIELD = 'password';
 const DATE_TIME_FORMAT = 'DD-MM-YYYY_HH-mm-ss';
-export { PASSWORD_FIELD, DATE_TIME_FORMAT };
+const TRANSACTION_STATUS = {
+  PENDING: 'pending',
+};
+
+export { PASSWORD_FIELD, DATE_TIME_FORMAT, TRANSACTION_STATUS };

--- a/src/helpers/tasks.js
+++ b/src/helpers/tasks.js
@@ -20,6 +20,7 @@ function printTaskSummary(taskData, shouldCalculateStartDate = false) {
       combineReport,
       saveLocation,
       includeFutureTransactions,
+      includePendingTransactions,
     } = taskData.output;
     console.log(colors.underline.bold('Task Summary'));
     writeSummaryLine('Scrapers', scrapers.map(scraper => SCRAPERS[scraper.id].name).join(', '));
@@ -36,6 +37,7 @@ function printTaskSummary(taskData, shouldCalculateStartDate = false) {
     writeSummaryLine('Save to location', saveLocation);
     writeSummaryLine('Create single report', combineReport ? 'Yes' : 'No');
     writeSummaryLine('Include future Transactions', includeFutureTransactions ? 'Yes' : 'No');
+    writeSummaryLine('Include pending Transactions', includePendingTransactions ? 'Yes' : 'No');
   }
 }
 

--- a/src/scrape/generate-reports.js
+++ b/src/scrape/generate-reports.js
@@ -1,7 +1,7 @@
 import json2csv from 'json2csv';
 import colors from 'colors/safe';
 import moment from 'moment';
-import { DATE_TIME_FORMAT } from '../constants';
+import { DATE_TIME_FORMAT, TRANSACTION_STATUS } from '../constants';
 import { writeFile } from '../helpers/files';
 
 function getReportFields(isSingleReport) {
@@ -51,18 +51,16 @@ function getReportFields(isSingleReport) {
 function filterTransactions(transactions, includeFutureTransactions, includePendingTransactions) {
   let result = transactions;
 
-  if (result && result.length) {
-    if (!includeFutureTransactions) {
-      const nowMoment = moment();
-      result = result.filter((txn) => {
-        const txnMoment = moment(txn.dateMoment);
-        return txnMoment.isSameOrBefore(nowMoment, 'day');
-      });
-    }
+  if (!includeFutureTransactions) {
+    const nowMoment = moment();
+    result = result.filter((txn) => {
+      const txnMoment = moment(txn.dateMoment);
+      return txnMoment.isSameOrBefore(nowMoment, 'day');
+    });
+  }
 
-    if (!includePendingTransactions) {
-      result = result.filter(txn => (txn.status || '').toLowerCase() !== 'pending');
-    }
+  if (!includePendingTransactions) {
+    result = result.filter(txn => txn.status !== TRANSACTION_STATUS.PENDING);
   }
 
   return result;

--- a/src/scrape/scrape-base.js
+++ b/src/scrape/scrape-base.js
@@ -11,6 +11,7 @@ async function prepareResults(scraperId, scraperName, scraperResult, combineInst
         account: account.accountNumber,
         dateMoment: moment(txn.date),
         payee: txn.description,
+        status: txn.status,
         amount: txn.type !== 'installments' || !combineInstallments ? txn.chargedAmount : txn.originalAmount,
         installment: txn.installments ? txn.installments.number : null,
         total: txn.installments ? txn.installments.total : null,

--- a/src/scrape/scrape-individual.js
+++ b/src/scrape/scrape-individual.js
@@ -9,7 +9,11 @@ import { readSettingsFile, writeSettingsFile } from '../helpers/settings';
 import scrape from './scrape-base';
 import { generateSeparatedReports } from './generate-reports';
 
-async function getParameters(defaultSaveLocation) {
+async function getParameters(
+  defaultSaveLocation,
+  includeFutureTransactions,
+  includePendingTransactions,
+) {
   const startOfMonthMoment = moment().startOf('month');
   const monthOptions = [];
   for (let i = 0; i < 6; i += 1) {
@@ -49,6 +53,18 @@ async function getParameters(defaultSaveLocation) {
       message: 'Save folder?',
       default: defaultSaveLocation,
     },
+    {
+      type: 'confirm',
+      name: 'includeFutureTransactions',
+      message: 'Include future transactions?',
+      default: !!includeFutureTransactions,
+    },
+    {
+      type: 'confirm',
+      name: 'includePendingTransactions',
+      message: 'Include pending transactions?',
+      default: !!includePendingTransactions,
+    },
   ]);
   return result;
 }
@@ -61,7 +77,13 @@ export default async function (showBrowser) {
     combineInstallments,
     startDate,
     saveLocation,
-  } = await getParameters(settings.saveLocation);
+    includeFutureTransactions,
+    includePendingTransactions,
+  } = await getParameters(
+    settings.saveLocation,
+    settings.includeFutureTransactions,
+    settings.includePendingTransactions,
+  );
 
   if (saveLocation !== settings.saveLocation) {
     settings.saveLocation = saveLocation;
@@ -79,7 +101,12 @@ export default async function (showBrowser) {
 
     try {
       const scrapedAccounts = await scrape(scraperId, credentials, options);
-      await generateSeparatedReports(scrapedAccounts, saveLocation);
+      await generateSeparatedReports(
+        scrapedAccounts,
+        saveLocation,
+        includeFutureTransactions,
+        includePendingTransactions,
+      );
     } catch (e) {
       console.error(e);
     }

--- a/src/scrape/scrape-individual.js
+++ b/src/scrape/scrape-individual.js
@@ -85,10 +85,10 @@ export default async function (showBrowser) {
     settings.includePendingTransactions,
   );
 
-  if (saveLocation !== settings.saveLocation) {
-    settings.saveLocation = saveLocation;
-    await writeSettingsFile(settings);
-  }
+  settings.saveLocation = saveLocation;
+  settings.includeFutureTransactions = includeFutureTransactions;
+  settings.includePendingTransactions = includePendingTransactions;
+  await writeSettingsFile(settings);
 
   const encryptedCredentials = await readJsonFile(`${CONFIG_FOLDER}/${scraperId}.json`);
   if (encryptedCredentials) {

--- a/src/scrape/scrape-task.js
+++ b/src/scrape/scrape-task.js
@@ -58,6 +58,7 @@ export default async function (showBrowser) {
       combineReport,
       saveLocation: saveLocationRootPath,
       includeFutureTransactions,
+      includePendingTransactions,
     } = taskData.output;
     const substractValue = dateDiffByMonth - 1;
     const startMoment = moment().subtract(substractValue, 'month').startOf('month');
@@ -86,22 +87,14 @@ export default async function (showBrowser) {
       }
     }
 
-    if (includeFutureTransactions) {
-      const nowMoment = moment();
-      for (let i = 0; i < reportAccounts.length; i += 1) {
-        const account = reportAccounts[i];
-        if (account.txns) {
-          account.txns = account.txns.filter((txn) => {
-            const txnMoment = moment(txn.dateMoment);
-            return txnMoment.isSameOrBefore(nowMoment, 'day');
-          });
-        }
-      }
-    }
-
     if (combineReport) {
       const saveLocation = `${saveLocationRootPath}/tasks/${taskName}`;
-      await generateSingleReport(reportAccounts, saveLocation);
+      await generateSingleReport(
+        reportAccounts,
+        saveLocation,
+        includeFutureTransactions,
+        includePendingTransactions,
+      );
     } else {
       const currentExecutionFolder = moment().format(DATE_TIME_FORMAT);
       const saveLocation = `${saveLocationRootPath}/tasks/${taskName}/${currentExecutionFolder}`;

--- a/src/scrape/scrape-task.js
+++ b/src/scrape/scrape-task.js
@@ -98,7 +98,12 @@ export default async function (showBrowser) {
     } else {
       const currentExecutionFolder = moment().format(DATE_TIME_FORMAT);
       const saveLocation = `${saveLocationRootPath}/tasks/${taskName}/${currentExecutionFolder}`;
-      await generateSeparatedReports(reportAccounts, saveLocation);
+      await generateSeparatedReports(
+        reportAccounts,
+        saveLocation,
+        includeFutureTransactions,
+        includePendingTransactions,
+      );
     }
   }
 }

--- a/src/setup/tasks/create-task-handler.js
+++ b/src/setup/tasks/create-task-handler.js
@@ -17,6 +17,7 @@ function createEmptyTaskData() {
       saveLocation: DOWNLOAD_FOLDER,
       combineReport: true,
       includeFutureTransactions: false,
+      includePendingTransactions: false,
     },
   };
 }

--- a/src/setup/tasks/modify-task-handler.js
+++ b/src/setup/tasks/modify-task-handler.js
@@ -68,6 +68,7 @@ const ModifyTaskHandler = (function createModifyTaskHandler() {
         saveLocation,
         combineReport,
         includeFutureTransactions,
+        includePendingTransactions,
       } = _private.get(this).taskData.output;
 
       const answers = await inquirer.prompt([
@@ -119,6 +120,12 @@ const ModifyTaskHandler = (function createModifyTaskHandler() {
           message: 'Include future transactions?',
           default: !!includeFutureTransactions,
         },
+        {
+          type: 'confirm',
+          name: 'includePendingTransactions',
+          message: 'Include pending transactions?',
+          default: !!includePendingTransactions,
+        },
       ]);
 
       _private.get(this).taskData.options.combineInstallments = answers.combineInstallments;
@@ -127,6 +134,8 @@ const ModifyTaskHandler = (function createModifyTaskHandler() {
       _private.get(this).taskData.output.combineReport = answers.combineReport;
       _private.get(this).taskData.output.includeFutureTransactions =
         answers.includeFutureTransactions;
+      _private.get(this).taskData.output.includePendingTransactions =
+        answers.includePendingTransactions;
       console.log(colors.notify('Changes saved'));
       await this.saveTask();
     }


### PR DESCRIPTION
# Goals
- provide option to include/exclude **future transactions** for both individual scrapers and tasks.
- provide option to include/exclude **pending transactions** for both individual scrapers and tasks.
- fix false condition for tasks filter by future transactions
- add column 'status' to the generated reports

@eshaham this PR closes #27 

## Options in tasks
![image](https://user-images.githubusercontent.com/4751797/38782359-f4fd3102-40fa-11e8-9900-91064d2c6a56.png)

## Options in individual scrapers
![image](https://user-images.githubusercontent.com/4751797/38782367-0f556b0a-40fb-11e8-9281-c280523300a2.png)

